### PR TITLE
Update doc format and record manual accuracy results

### DIFF
--- a/docs/entity/Annotation.md
+++ b/docs/entity/Annotation.md
@@ -1,11 +1,15 @@
 # Entity: Annotation
+
 `Annotations`, a form of metadata, provide data about a program that is not part of the program itself. Annotations have no direct effect on the operation of the code they annotate.
+
 ## Supported pattern
+
 ```yaml
-name : AnnotationDeclaration
+name: Annotation
 ```
-### Syntax : Annotation Definitions
-```yaml
+### Syntax: Annotation Definitions
+
+```text
 AnnotationTypeDeclaration:
    [ Javadoc ] { ExtendedModifier } @ interface Identifier
                 { { AnnotationTypeBodyDeclaration | ; } }
@@ -16,28 +20,51 @@ AnnotationTypeDeclaration:
        EnumDeclaration
        AnnotationTypeDeclaration
 ```
-### Examples : 
-- Annotation declaration
-```java
-package hello;
 
-@interface ClassPreamble {
-   String author();
-   String date();
-   int currentRevision() default 1;
-   String lastModified() default "N/A";
-   String lastModifiedBy() default "N/A";
-   // Note use of array
-   String[] reviewers();
+#### Examples:
+
+* Annotation declared in default package
+
+```java
+@interface Foo {
+   /* ... */
 }
 ```
+
 ```yaml
-name: AnnotationDeclaration
-entities:
-    filter: annotation
+name: Annotation In Default Package
+entity:
+    filter: Annotation
+    r:
+        d: Type
+        e: .
+        s: .
+        u: xInterface
     items:
-        -   name: ClassPreamble
-            loc: [ 3, 0, 11, 0 ]
-            rawType: hello.ClassPreamble
-            qualifiedName: hello.ClassPreamble
+        -   name: Foo
+            qualifiedName: Foo
+```
+
+* Annotation declared in explicitly named package
+
+```java
+package foo;
+
+@interface Bar {
+   /* ... */
+}
+```
+
+```yaml
+name: Annotation In Named Package
+entity:
+    filter: Annotation
+    items:
+        -   name: Bar
+            qualifiedName: foo.Bar
+            r:
+                d: Type
+                e: .
+                s: .
+                u: .
 ```

--- a/docs/entity/AnnotationMember.md
+++ b/docs/entity/AnnotationMember.md
@@ -1,57 +1,44 @@
 # Entity: Annotation Member
+
 `Annotation Member` looks a lot like a method, which provides extra actions about this annotation.
+
 ## Supported pattern
+
 ```yaml
-name : AnnotationMemberDeclaration
+name: Annotation Member
 ```
-### Syntax : AnnotationMember Definitions
-```yaml
+
+### Syntax: AnnotationMember Definitions
+
+```text
 AnnotationTypeMemberDeclaration:
    [ Javadoc ] { ExtendedModifier }
        Type Identifier ( ) [ default Expression ] ;
 ```
-### Examples : 
-- Annotation declaration
-```java
-package hello;
 
-@interface ClassPreamble {
-   String author();
-   String date();
-   int currentRevision() default 1;
-   String lastModified() default "N/A";
-   String lastModifiedBy() default "N/A";
-   // Note use of array
-   String[] reviewers();
+#### Examples:
+
+* Annotation member declaration
+
+```java
+@interface Foo {
+   String bar();
+   int baz() default 1;     // Assign a default value
 }
 ```
+
 ```yaml
-name: AnnotationMemberDeclaration
-entities:
-    filter: annotation
+name: Annotation Member Declaration
+entity:
+    filter: Annotation Member
+    r:
+        d: Function
+        e: .
+        s: Field
+        u: Abstract Method
     items:
-        -   name: author
-            loc: [ 4, 4, 4, 19 ]
-            rawType: String
-            qualifiedName: helloJDT.ClassPreamble.author
-        -   name: date
-            loc: [ 5, 4, 5, 17 ]
-            rawType: String
-            qualifiedName: helloJDT.ClassPreamble.date
-        -   name: currentRevision
-            loc: [ 6, 4, 6, 35 ]
-            rawType: int
-            qualifiedName: helloJDT.ClassPreamble.currentRevision
-        -   name: lastModified
-            loc: [ 7, 4, 7, 39 ]
-            rawType: String
-            qualifiedName: helloJDT.ClassPreamble.lastModified
-        -   name: lastModifiedBy
-            loc: [ 8, 4, 8, 41 ]
-            rawType: String
-            qualifiedName: helloJDT.ClassPreamble.lastModifiedBy
-        -   name: reviewers
-            loc: [ 10, 4, 10, 24 ]
-            rawType: String-
-            qualifiedName: helloJDT.ClassPreamble.reviewers
+        -   name: bar
+            qualifiedName: Foo.bar
+        -   name: baz
+            qualifiedName: Foo.baz
 ```

--- a/docs/entity/Class.md
+++ b/docs/entity/Class.md
@@ -1,11 +1,16 @@
 # Entity : Class
+
 A class is a blueprint or prototype from which objects are created,it models the state and behavior of a real-world object.
+
 ## Supported pattern
+
 ```yaml
-name : ClassDeclaration
+name : Class
 ```
-### Syntax : Class Definitions
-```yaml
+
+### Syntax: Class Definitions
+
+```text
 Class Declaration:
       [ Javadoc ] { ExtendedModifier } class Identifier
                         [ < TypeParameter { , TypeParameter } > ]
@@ -16,122 +21,101 @@ Class Declaration:
 AnonymousClassDeclaration:
       { ClassBodyDeclaration }
 ```
-### Examples : 
-- Class declaration
-```java
-package hello;
 
+#### Examples:
+
+* Class declaration
+
+```java
 class Foo{
-    int a;
+    /* ... */
 }
 ```
+
 ```yaml
 name: Class Declaration
-entities:
-    filter: class
+entity:
+    filter: Class
+    r:
+        d: Type
+        e: .
+        s: .
+        u: .
     items:
-        -   name: foo
-            qualifiedName : hello.Foo
-            loc: [ 3, 0, 5, 0]
-            id : 3
-            parentId : 2
-            childrenIds : [4]
+        -   name: Foo
+            qualifiedName : Foo
 ```
-- Inner class declaration
-```java
-package hello;
 
-class Foo{
-    int a;
-    class Inner{
-        int b;
+* Nested class declaration
+
+```java
+class Foo {
+    class Nested {
+        /* ... */
     }
 }
 ```
+
 ```yaml
-name: NestedClassDeclaration
-entities:
-    filter: class
+name: Nested Class Declaration
+entity:
+    filter: Class
+    r:
+        d: Type
+        e: .
+        s: .
+        u: .
     items:
-        -   name: foo
-            qualifiedName : hello.Foo
-            loc: [ 3, 0, 8, 0]
-        -   name: inner
-            qualifiedName : hello.Foo.Inner
-            loc: [5, 4, 7, 4]
+        -   name: Foo
+            qualifiedName : Foo
+        -   name: Nested
+            qualifiedName : Foo.Nested
 ```
-- Anonymous class declaration
+
+* Anonymous class declaration
+
 ```java
-public class HelloWorldAnonymousClasses {
+class Foo {
   
-    interface HelloWorld {
-        void greet();
-        void greetSomeone(String someone);
+    interface Bar {
+        void a();
     }
   
-    public void sayHello() {
-        
-        class EnglishGreeting implements HelloWorld {
-            String name = "world";
-            public void greet() {
-                greetSomeone("world");
+    public void doThings() {
+
+        /**
+         * Below creates 2 anonymous class which
+         * implements interface `Bar` instantly
+         */
+        Bar anony0 = new Bar() {
+            public void a() {
+                /* ... */
             }
-            public void greetSomeone(String someone) {
-                name = someone;
-                System.out.println("Hello " + name);
-            }
-        }
-      
-        HelloWorld englishGreeting = new EnglishGreeting();
-        
-        HelloWorld frenchGreeting = new HelloWorld() {
-            String name = "tout le monde";
-            public void greet() {
-                greetSomeone("tout le monde");
-            }
-            public void greetSomeone(String someone) {
-                name = someone;
-                System.out.println("Salut " + name);
+        };
+
+        Bar anony1 = new Bar() {
+            public void a() {
+                /* ... */
             }
         };
         
-        HelloWorld spanishGreeting = new HelloWorld() {
-            String name = "mundo";
-            public void greet() {
-                greetSomeone("mundo");
-            }
-            public void greetSomeone(String someone) {
-                name = someone;
-                System.out.println("Hola, " + name);
-            }
-        };
-        englishGreeting.greet();
-        frenchGreeting.greetSomeone("Fred");
-        spanishGreeting.greet();
     }         
 }
 ```
+
 ```yaml
 name: Anonymous Class Declaration
-entities:
-    filter: class
+entity:
+    filter: Class
+    r:
+        d: r/Create
+        e: .
+        s: .
+        u: .
     items:
-        -   name: HelloWorldAnonymousClasses
-            qualifiedName : HelloWorldAnonymousClasses
-            rawType: HelloWorldAnonymousClasses
-            loc: [ 1, 0, 53, 0]
-            modifiers: public
-        -   name: EnglishGreeting
-            qualifiedName : HelloWorldAnonymousClasses.sayHello.EnglishGreeting
-            rawType: HelloWorldAnonymousClasses.sayHello.EnglishGreeting
-            loc: [ 9, 8, 18, 8]
-            modifiers: public
-        -   name: Anonymous_Class
-            qualifiedName : HelloWorldAnonymousClasses.sayHello.Anonymous_Class
-            rawType: HelloWorldAnonymousClasses.HelloWorld
-            loc: [ 25, 53, 32, 8]
-        -   name: Anonymous_Class
-            qualifiedName : HelloWorldAnonymousClasses.sayHello.Anonymous_Class
-            rawType: HelloWorldAnonymousClasses.HelloWorld
-            loc: [36, 54, 45, 8]
+        -   name: <Anonymous type="Class">
+            qualifiedName : Foo.doThings.<Anonymous type="Class">
+        -   name: <Anonymous type="Class">
+            qualifiedName : Foo.doThings.<Anonymous type="Class">
+
 ```

--- a/docs/entity/Enum.md
+++ b/docs/entity/Enum.md
@@ -1,11 +1,16 @@
 # Entity: Enum
-An `enum type` is a special data type that enables for a variable to be a set of predefined constants. The variable must be equal to one of the values that have been predefined for it. 
+
+An `enum type` is a special data type that enables for a variable to be a set of predefined constants. The variable must be equal to one of the values that have been predefined for it.
+
 ## Supported pattern
+
 ```yaml
-name : EnumDeclaration
+name: Enum
 ```
-### Syntax : Enum Definitions
-```yaml
+
+### Syntax: Enum Definitions
+
+```text
 EnumDeclaration:
      [ Javadoc ] { ExtendedModifier } enum Identifier
          [ implements Type { , Type } ]
@@ -14,22 +19,51 @@ EnumDeclaration:
          [ ; { ClassBodyDeclaration | ; } ]
          }
 ```
-### Examples : 
-- Enum declaration
-```java
-package hello;
 
-public enum Day {
-    SUNDAY, MONDAY, TUESDAY, WEDNESDAY,
-    THURSDAY, FRIDAY, SATURDAY 
+#### Examples:
+
+* Enum declared in default package
+
+```java
+enum Foo {
+    /* ... */
 }
 ```
+
 ```yaml
-name: Enum Declaration
-entities:
-    filter: enum
+name: Enum Declared In Default Package
+entity:
+    filter: Enum
+    r:
+        d: Type
+        e: .
+        s: .
+        u: .
     items:
-        -   name: Day
-            qualifiedName: hello.Day
-            loc: [ 3, 0, 6, 0]
+        -   name: Foo
+            qualifiedName: Foo
+```
+
+* Enum declared in named package
+
+```java
+package foo;
+
+enum Bar {
+    /* ... */
+}
+```
+
+```yaml
+name: Enum Declared In Named Package
+entity:
+    filter: Enum
+    r:
+        d: Type
+        e: .
+        s: .
+        u: .
+    items:
+        -   name: Bar
+            qualifiedName: foo.Bar
 ```

--- a/docs/entity/EnumConstant.md
+++ b/docs/entity/EnumConstant.md
@@ -1,40 +1,78 @@
-# Entity: Enum
-An `enum constant` is a set of predefined constants defined in enum. 
+# Entity: Enum Constant
+
+An `enum constant` is a set of predefined constants defined in enum.
+
 ## Supported pattern
+
 ```yaml
-name : EnumConstantDeclaration
+name: Enum Constant
 ```
-### Syntax : Enum Constant Definitions
-```yaml
+### Syntax: Enum Constant Definitions
+
+```text
 EnumConstantDeclaration:
      [ Javadoc ] { ExtendedModifier } Identifier
          [ ( [ Expression { , Expression } ] ) ]
          [ AnonymousClassDeclaration ]
 ```
-### Examples : 
-- Enum constant declaration
-```java
-package hello;
 
-public enum Day {
-    SUNDAY, MONDAY, TUESDAY, WEDNESDAY,
-    THURSDAY, FRIDAY, SATURDAY 
+#### Examples:
+
+* Simple enum constant declaration
+
+```java
+enum Foo {
+    BAR
 }
 ```
+
 ```yaml
-name: Enum Constant Declaration
-entities:
-    filter: enum
-    exact: false
+name: Simple Enum Constant
+entity:
+    filter: Enum Constant
+    r:
+        d: Var
+        e: .
+        s: .
+        u: .
     items:
-        -   name: SUNDAY
-            qualifiedName: helloJDT.Day.SUNDAY
-            loc: [ 4, 4, 4, 9 ]
-        -   name: MONDAY
-            qualifiedName: helloJDT.Day.MONDAY
-            loc: [ 4, 12, 4, 17 ]
-        -   name: THURSDAY
-            qualifiedName: helloJDT.Day.THURSDAY
-            loc: [ 4, 4, 5, 11 ]
-                     
+        -   name: BAR
+            qualifiedName: Foo.BAR
+```
+
+* Enum with methods
+
+```java
+enum Planet {
+    MERCURY (3.303e+23, 2.4397e6),              // <--- Enum constant
+    VENUS   (4.869e+24, 6.0518e6);              // <--- Enum constant
+
+    private final double mass;
+    private final double radius;
+    Planet(double mass, double radius) {
+        this.mass = mass;
+        this.radius = radius;
+    }
+    private double mass() { return mass; }
+    private double radius() { return radius; }
+
+    public static final double G = 6.67300E-11; // <--- NOT enum constant
+}
+```
+
+```yaml
+name: Enum Constant With Methods
+entity:
+    filter: Enum Constant
+    exact: true
+    r:
+        d: Var
+        e: .
+        s: .
+        u: .
+    items:
+        -   name: MERCURY
+            qualifiedName: Planet.MERCURY
+        -   name: VENUS
+            qualifiedName: Planet.VENUS
 ```

--- a/docs/entity/Interface.md
+++ b/docs/entity/Interface.md
@@ -1,11 +1,16 @@
-# Entity : Interface
+# Entity: Interface
+
 An `interface` is a contract between a class and the outside world. When a class implements an interface, it promises to provide the behavior published by that interface.
+
 ## Supported pattern
+
 ```yaml
-name : InterfaceDeclaration
+name: Interface
 ```
-### Syntax : Interface Definitions
-```yaml
+
+### Syntax: Interface Definitions
+
+```text
 Interface Declaration:
       [ Javadoc ] { ExtendedModifier } interface Identifier
                         [ < TypeParameter { , TypeParameter } > ]
@@ -13,99 +18,52 @@ Interface Declaration:
                         [ permits Type { , Type } ]
                         { { InterfaceBodyDeclaration | ; } }
 ```
-### Examples : 
-- Interface declaration
+
+#### Examples:
+
+* Interface declaration
+
 ```java
-package helloJDT.pkg;
-
-public interface JDTpkg_2 {
-
-    public String b = null;
-
-    public abstract void imply();
+interface Foo {
+    /* ... */
 }
 
 ```
+
 ```yaml
 name: Interface Declaration
-entities:
-    filter: interface
+entity:
+    filter: Interface
+    r:
+        d: Type
+        e: .
+        s: .
+        u: .
     items:
-        -   name: JDTpkg_2
-            loc: [ 3, 0, 8, 0 ]
-            rawType: helloJDT.pkg.JDTpkg_2
-            qualifiedName: helloJDT.pkg.JDTpkg_2
-            category: Interface
-            modifiers: public
+        -   name: Foo
+            qualifiedName: Foo
 ```
-- Inner interface
+
+- Interface as class body
+
 ```java
-package helloJDT;
-
-public class HelloWorldAnonymousClasses {
-
-    interface HelloWorld {
-        void greet();
-        void greetSomeone(String someone);
-    }
-
-    public void sayHello() {
-
-        class EnglishGreeting implements HelloWorld {
-            String name = "world";
-            public void greet() {
-                greetSomeone("world");
-            }
-            public void greetSomeone(String someone) {
-                name = someone;
-                System.out.println("Hello " + name);
-            }
-        }
-
-        HelloWorld englishGreeting = new EnglishGreeting();
-
-        HelloWorld frenchGreeting = new HelloWorld() {
-            String name = "tout le monde";
-            public void greet() {
-                greetSomeone("tout le monde");
-            }
-            public void greetSomeone(String someone) {
-                name = someone;
-                System.out.println("Salut " + name);
-            }
-        };
-
-        HelloWorld spanishGreeting = new HelloWorld() {
-            String name = "mundo";
-            public void greet() {
-                greetSomeone("mundo");
-            }
-            public void greetSomeone(String someone) {
-                name = someone;
-                System.out.println("Hola, " + name);
-            }
-        };
-        englishGreeting.greet();
-        frenchGreeting.greetSomeone("Fred");
-        spanishGreeting.greet();
-    }
-
-    public static void main(String... args) {
-        HelloWorldAnonymousClasses myApp =
-                new HelloWorldAnonymousClasses();
-        myApp.sayHello();
+class Foo {
+    interface Bar {
+        void baz();
     }
 }
 
 ```
 ```yaml
-name: Nested Interface Declaration
-entities:
-    filter: interface
+name: Interface As Class Body
+entiy:
+    filter: Interface
+    r:
+        d: Type
+        e: .
+        s: .
+        u: .
     items:
-        -   name: HelloWorld
-            loc: [ 5, 4, 8, 4 ]
-            rawType: helloJDT.HelloWorldAnonymousClasses.HelloWorld
-            qualifiedName: helloJDT.HelloWorldAnonymousClasses.HelloWorld
-            category: Interface
+        -   name: Bar
+            qualifiedName: Foo.Bar
 ```

--- a/docs/entity/Method.md
+++ b/docs/entity/Method.md
@@ -1,11 +1,15 @@
-# Entity : Method
+# Entity: Method
+
 `Method` is an entity inside the `class` to perform specific activity.
+
 ## Supported pattern
+
 ```yaml
-name : MethodDeclaration
+name: Method
 ```
-### Syntax : Method Definitions
-```yaml
+### Syntax: Method Definitions
+
+```text
 MethodDeclaration:
     [ Javadoc ] { ExtendedModifier } [  TypeParameter { , TypeParameter } ] ( Type | void )
         Identifier (
@@ -27,15 +31,15 @@ CompactConstructorDeclaration:
         Identifier
         ( Block | ; )
 ```
-### Examples : 
-- Method declaration
-```java
-package helloJDT.pkg.test;
 
-public class Person {
+#### Examples:
+
+* Method declaration
+
+```java
+class Person {
     private String name;
-    private int age;
-    private static String msg="hello world";
+
     public String getName() {
         return name;
     }
@@ -43,97 +47,21 @@ public class Person {
     public void setName(String name) {
         this.name = name;
     }
-
-    public int getAge() {
-        return age;
-    }
-
-    public void setAge(int age) {
-        this.age = age;
-    }
-
-    public Person() {
-    }
-
-    private Person(String name) {
-        this.name = name;
-        System.out.println(age);
-    }
-
-    public void fun() {
-        System.out.println("fun "+Person.msg);
-    }
-
-    public void fun(String name,int age) {
-        System.out.println("我叫"+name+",今年"+age+"岁");
-    }
 }
-
 ```
+
 ```yaml
 name: Method Declaration
-entities:
-    filter: method
+entity:
+    filter: Method
+    r:
+        d: Function
+        e: .
+        s: .
+        u: .
     items:
         -   name: getName
-            location : [7, 4, 9, 4]
-            rawType: String
             qualifiedName: helloJDT.pkg.test.Person.getName
-            category: Method
-            modifiers: public
         -   name: setName
-            location : [11, 4, 13, 4]
-            rawType: void
             qualifiedName: helloJDT.pkg.test.Person.setName
-            category: Method
-            modifiers: public
-            parameter:
-                - types: String
-                - names: name
-        -   name: getAge
-            location : [15, 4, 17, 4]
-            rawType: int
-            qualifiedName: helloJDT.pkg.test.Person.getAge
-            category: Method
-            modifiers: public
-        -   name: setAge
-            location : [19, 4, 21, 4]
-            rawType: void
-            qualifiedName: helloJDT.pkg.test.Person.setAge
-            category: Method
-            modifiers: public
-            parameter:
-                - types: int
-                - names: age
-        -   name: Person
-            location : [23, 4, 24, 4]
-            rawType: helloJDT.pkg.test.Person.Person
-            qualifiedName: helloJDT.pkg.test.Person.Person
-            category: Method
-            modifiers: public
-        -   name: Person
-            location : [26, 4, 29, 4]
-            rawType: helloJDT.pkg.test.Person.Person
-            qualifiedName: helloJDT.pkg.test.Person.Person
-            category: Method
-            modifiers: private
-            parameter:
-                - types: String
-                - names: name
-        -   name: fun
-            location : [31, 4, 33, 4]
-            rawType: void
-            qualifiedName: helloJDT.pkg.test.Person.fun
-            category: Method
-            modifiers: public
-        -   name: fun
-            location : [35, 4, 37, 4]
-            rawType: void
-            qualifiedName: helloJDT.pkg.test.Person.fun
-            category: Method
-            modifiers: public
-            parameter:
-                - types: String int
-                - names:name age
 ```
-

--- a/docs/entity/Package.md
+++ b/docs/entity/Package.md
@@ -1,42 +1,65 @@
-# Entity : Package
+# Entity: Package
+
 A `package entity` is a namespace which bundles types together and arranges file system so that compiler can find source files.
+
 ## Supported pattern
+
 ```yaml
-name : PackageDeclaration
+name: Package
 ```
-### Syntax : Package Definitions
-```yaml
+
+### Syntax: Package Definitions
+
+```text
 Package Declaration:
     [ Javadoc ] { Annotation } package Name ;
 ```
-### Examples : 
-- Package declaration (Single)
+
+#### Examples:
+
+* Package declaration (Single)
+
 ```java
-package hello;
+package foo;
 ```
+
 ```yaml
-name: Package Declaration
-entities:
-    filter: package
+name: Single Package Declaration
+entity:
+    filter: Package
+    r:
+        d: .
+        e: .
+        s: .
+        u: .
     items:
-        -   name: hello
-            qualifiedName : hello
-            id : 0
+        -   name: foo
+            qualifiedName: foo
 ```
-- Package declaration (Multiple)
+
+* Package declaration (Multiple)
+
 ```java
-package hello.test;
+package foo.bar;
 ```
+
 ```yaml
-name: Package Declaration
-entities:
-    filter: package
+name: Multilayer Package Declaration
+entity:
+    filter: Package
     items:
-        -   name: hello
-            qualifiedName : hello
-            id : 0
-            childrenIds : [1]
-        -   name: hello
-            qualifiedName : hello
-            id : 1
+        -   name: foo
+            qualifiedName: foo
+            r:
+                d: x
+                e: .
+                s: .
+                u: .
+        -   name: bar
+            qualifiedName: foo.bar
+            r:
+                d: .
+                e: .
+                s: .
+                u: .
 ```

--- a/docs/entity/Variable.md
+++ b/docs/entity/Variable.md
@@ -1,11 +1,16 @@
-# Entity : Variable
+# Entity: Variable
+
 A `variable entity' is a container which stores values.
+
 ## Supported pattern
+
 ```yaml
-name : VariableDeclaration
+name: Variable
 ```
-### Syntax : Variable Definitions
-```yaml
+
+### Syntax: Variable Definitions
+
+```text
  VariableDeclarationExpression:
     { ExtendedModifier } Type VariableDeclarationFragment
          { , VariableDeclarationFragment }
@@ -23,194 +28,221 @@ name : VariableDeclaration
 
  SingleVariableDeclaration:
     { ExtendedModifier } Type {Annotation} [ ... ] Identifier { Dimension } [ = Expression ]
-
 ```
-### Examples : 
-- Field (global variable) declaration 
-```java
-package hello;
 
-class foo{
+#### Examples:
+
+* Field (global variable) declaration 
+
+```java
+class Foo {
     public int a;
 }
 ```
+
 ```yaml
 name: Field Declaration
-entities:
-    filter: variable
+entity:
+    filter: Variable
+    r:
+        d: Var
+        e: .
+        s: Field
+        u: .
     exact: true
     items:
         -   name : a
-            category : Variable
-            qualifiedName : hello.foo.a
-            rawType : int
-            modifiers : public
+            qualifiedName : Foo.a
             global : true
 ```
-- Variable Declaration Statement (single var)
+
+* Variable Declaration Statement (single var)
+
 ```java
-public class foo{
-        
-    public String getHello(){
+class Foo {
+    public String getHello() {
         String a = "hello";
         return a;
     }
 }
 ```
+
 ```yaml
 name: Variable Declaration Statement
-entities:
-    filter: variable
+entity:
+    filter: Variable
+    r:
+        d: Var
+        e: .
+        s: x
+        u: .
     exact: true
     items:
         -   name : a
-            category : Variable
-            qualifiedName : foo.getHello.a
-            rawType : String
+            qualifiedName : Foo.getHello.a
             global : false
 ```
-- Variable Declaration Statement (multiple vars)
+
+* Variable Declaration Statement (multiple vars)
+
 ```java
-public class foo{
-        
-    public String getHello(){
+class Foo{
+    public String getHello() {
         String a, b, c;
         a = "hello";
         return a;
     }
 }
 ```
+
 ```yaml
 name: Multi Variable Declaration Statement
-entities:
-    filter: variable
+entity:
+    filter: Variable
+    r:
+        d: Var
+        e: .
+        s: x
+        u: .
     exact: true
     items:
         -   name : a
             category : Variable
-            qualifiedName : foo.getHello.a
+            qualifiedName : Foo.getHello.a
             rawType : String
             global : false
         -   name : b
             category : Variable
-            qualifiedName : foo.getHello.b
+            qualifiedName : Foo.getHello.b
             rawType : String
             global : false
         -   name : c
             category : Variable
-            qualifiedName : foo.getHello.c
+            qualifiedName : Foo.getHello.c
             rawType : String
             global : false
 ```
-- Single Variable Declaration (parameter)
+
+* Single Variable Declaration (parameter)
+
 ```java
-class foo {
-    
+class Foo {
     public int max(int num1, int num2){
         return Math.max(num1, num2);
     }
 }
 ```
+
 ```yaml
 name: Parameter Declaration
-entities:
-    filter: variable
+entity:
+    filter: Variable
+    r:
+        d: o/hidden
+        e: .
+        s: x
+        u: Parameter
     exact: true
     items:
         -   name : num1
-            category : Variable
-            qualifiedName : foo.max.num1
+            qualifiedName : Foo.max.num1
             rawType : int
             global : false
         -   name : num2
-            category : Variable
-            qualifiedName : foo.max.num2
+            qualifiedName : Foo.max.num2
             rawType : int
             global : false
 ```
-- Single Variable Declaration (catch exception)
+
+* Single Variable Declaration (catch exception)
+
 ```java
-public class foo{
-    
-     public static void main(String args[]){
-          try{
-             int a[] = new int[2];
-             System.out.println("Access element three :" + a[3]);
-          }catch(ArrayIndexOutOfBoundsException e){
-             System.out.println("Exception thrown  :" + e);
-          }
-          System.out.println("Out of the block");
-     }
+// Foo.java
+public class Foo{
+    public static void main(String args[]) {
+        try{
+            int a[] = new int[2];
+            a[3] = 1;
+        } catch(ArrayIndexOutOfBoundsException e) {
+            System.out.println(e);
+        }
+    }
 }
 ```
+
 ```yaml
 name: Catch Parameter Declaration
-entities:
-    filter: variable
-    exact: false
+entity:
+    filter: Variable
+    r:
+        d: x
+        e: .
+        s: x
+        u: Catch Parameter
     items:
-        -   name : a
-            category : Variable
-            qualifiedName : foo.main.a
-            rawType : int
-            global : false
-        -   name : e
-            category : Variable
-            qualifiedName : foo.main.e
-            global : false
+        -   name: e
+            qualifiedName: Foo.main.e
+            global: false
 ```
-- Single Variable Declaration (enhanced-for statement)
-```java
-public class foo{
 
-       public ArrayList<Integer> printTest(){
-            ArrayList<Integer> result = new ArrayList<>();
-            for (Integer integer : this.test) {
-                if (integer > this.getB()) {
-                    result.add(integer);
-                }
+* Single Variable Declaration (enhanced-for statement)
+
+```java
+// Foo.java
+public class Foo{
+    public ArrayList<Integer> printTest() {
+        ArrayList<Integer> result = new ArrayList<>();
+        for (Integer integer : this.test) {
+            if (integer > this.getB()) {
+                result.add(integer);
             }
-            return result;
         }
+        return result;
+    }
 }
 ```
+
 ```yaml
 name: For Loop Variable
 entities:
-    filter: variable
-    exact: true
+    filter: Variable
+    r:
+        d: Var
+        e: .
+        s: x
+        u: .
     items:
-        -   name : result
-            category : Variable
-            qualifiedName : foo.printTest.result
-            rawType : ArrayList<Integer>
-            global : false
         -   name : integer
-            category : Variable
-            qualifiedName : foo.printTest.integer
+            qualifiedName : Foo.printTest.integer
             rawType : Integer
             global : false
 ```
-- Variable Declaration Expression (for statement)
-```java
-public class foo{
 
+* Variable Declaration Expression (for statement)
+
+```java
+// Foo.java
+public class Foo{
     public void imply() {
-        for (int i=0; i<10; i++){
+        for (int i=0; i<10; i++) {
             System.out.println(i);
         }
     }
 }
 ```
+
 ```yaml
 name: Variable Declaration Expression
 entities:
-    filter: variable
-    exact: true
+    filter: Variable
+    r:
+        d: Var
+        e: .
+        s: x
+        u: .
     items:
         -   name : i
-            category : Variable
-            qualifiedName : foo.imply.i
+            qualifiedName : Foo.imply.i
             rawType : int
             global : false
 ```


### PR DESCRIPTION
I have simplified code examples in docs/entity and modified keywords to match our new guidance, and used special format to record the manual accuracy comparing results. Please accept this and write your further docs in this format.