### PR TITLE
fix "\u003c" and "\u003e" bug in json file

### DIFF
--- a/src/main/java/TempOutput/CreateFileUtil.java
+++ b/src/main/java/TempOutput/CreateFileUtil.java
@@ -47,7 +47,7 @@ public class CreateFileUtil {
 
             String result = jsonString;
 //            write.write(tool.formatJson(result));
-            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
             JsonElement je = JsonParser.parseString(result);
             String res = gson.toJson(je);
             write.write(res);


### PR DESCRIPTION
gson interprete "<" and ">" as "\u003c" and "\u003e", which can be solved by using "disableHTMLEscaping" method.
![Snipaste_2023-03-12_11-30-54](https://user-images.githubusercontent.com/46697655/224522628-943f0317-5f6c-4318-acea-936120713714.png)
