### PR TITLE
Fix output OOM error when the output file larger than 1g

### DIFF
--- a/src/main/java/TempOutput/CreateFileUtil.java
+++ b/src/main/java/TempOutput/CreateFileUtil.java
@@ -9,6 +9,7 @@ import entity.adapter.*;
 import entity.dto.EnreDTO;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public class CreateFileUtil {
@@ -46,7 +47,7 @@ public class CreateFileUtil {
                 new EntityDTOAdapter()
                 ));
             Gson gson = builder.disableHtmlEscaping().setPrettyPrinting().create();
-            JsonWriter out = new JsonWriter(new BufferedWriter(new FileWriter(fullPath)));
+            JsonWriter out = new JsonWriter(new BufferedWriter(new FileWriter(fullPath, Charset.forName("UTF-32"))));
             out.setIndent("  ");
             gson.toJson(enre, EnreDTO.class, out);
             out.close();


### PR DESCRIPTION
The PR specify the charset UTF-32, so the tool support outputting files larger than 1g in size.